### PR TITLE
Pylint output adjustment

### DIFF
--- a/autohooks/plugins/pylint/pylint.py
+++ b/autohooks/plugins/pylint/pylint.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import subprocess
+import sys
 
 from autohooks.api import ok, error, out
 from autohooks.api.path import match
@@ -92,7 +93,9 @@ def precommit(config=None, **kwargs):  # pylint: disable=unused-argument
             )
             out_, _ = proc.communicate()
             if out_:
-                out_ = out_.decode(encoding='utf-8').split('\n')
+                out_ = out_.decode(
+                    encoding=sys.getdefaultencoding(), errors='redirect'
+                ).split('\n')
                 for line in out_:
                     out(line)
             if proc.returncode:

--- a/autohooks/plugins/pylint/pylint.py
+++ b/autohooks/plugins/pylint/pylint.py
@@ -94,7 +94,7 @@ def precommit(config=None, **kwargs):  # pylint: disable=unused-argument
             out_, _ = proc.communicate()
             if out_:
                 out_ = out_.decode(
-                    encoding=sys.getdefaultencoding(), errors='redirect'
+                    encoding=sys.getdefaultencoding(), errors='replace'
                 ).split('\n')
                 for line in out_:
                     out(line)

--- a/autohooks/plugins/pylint/pylint.py
+++ b/autohooks/plugins/pylint/pylint.py
@@ -16,8 +16,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import subprocess
+import sys
 
-from autohooks.api import ok, error
+from io import StringIO
+from autohooks.api import ok, error, out
 from autohooks.api.path import match
 from autohooks.api.git import get_staged_status, stash_unstaged_changes
 
@@ -87,7 +89,13 @@ def precommit(config=None, **kwargs):  # pylint: disable=unused-argument
             args = ['pylint']
             args.extend(arguments)
             args.append(str(f.absolute_path()))
+            stdout_file = sys.stdout
+            pylint_out = StringIO()
+            sys.stdout = pylint_out
             status = subprocess.call(args)
+            sys.stdout = stdout_file
+            for line in pylint_out.readlines():
+                out(line)
             if status:
                 error('Linting error(s) found in {}.'.format(str(f.path)))
             else:


### PR DESCRIPTION
Awesome output adjustment, so the Pylint output is indented as intended. :D 

**Example**:

```
y0urself@Jaspars-MBP:~/Documents/greenbone/autohooks-plugin-pylint$ git commit -m "Redirect the pylint output ... make it smoothier with the autohooks"
autohooks => pre-commit
    Running autohooks.plugins.black
        Running black on autohooks/plugins/pylint/pylint.py                                                                      [ ok ]
    Running autohooks.plugins.pylint
        ************* Module pylint.pylint
        autohooks/plugins/pylint/pylint.py:96:18: W0612: Unused variable 'err' (unused-variable)
        autohooks/plugins/pylint/pylint.py:19:0: W0611: Unused import sys (unused-import)
        autohooks/plugins/pylint/pylint.py:20:0: W0611: Unused import tabnanny (unused-import)
        autohooks/plugins/pylint/pylint.py:22:0: W0611: Unused StringIO imported from io (unused-import)

        Linting error(s) found in autohooks/plugins/pylint/pylint.py.                                                         [ error ]
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] [CHANGELOG](https://github.com/greenbone/autohooks-plugin-pylint/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
