### PR TITLE
Change: Resolve deprecation warnings in GitHub workflows

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -13,9 +13,9 @@ jobs:
     strategy:
         matrix:
           python-version:
-            - 3.7
-            - 3.8
-            - 3.9
+            - "3.7"
+            - "3.8"
+            - "3.9"
             - "3.10"
             - "3.11"
     steps:
@@ -24,16 +24,16 @@ jobs:
         uses: greenbone/actions/lint-python@v2
         with:
           packages: autohooks tests
-          version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
   type-checking:
     name: Type-checker
     runs-on: 'ubuntu-latest'
     strategy:
         matrix:
           python-version:
-            - 3.7
-            - 3.8
-            - 3.9
+            - "3.7"
+            - "3.8"
+            - "3.9"
             - "3.10"
             - "3.11"
     steps:
@@ -42,16 +42,16 @@ jobs:
         uses: greenbone/actions/mypy-python@v2
         with:
           packages: autohooks
-          version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
   test:
     name: Run all tests
     runs-on: 'ubuntu-latest'
     strategy:
         matrix:
           python-version:
-            - 3.7
-            - 3.8
-            - 3.9
+            - "3.7"
+            - "3.8"
+            - "3.9"
             - "3.10"
             - "3.11"
     steps:
@@ -59,7 +59,7 @@ jobs:
       - name: Install poetry and dependencies
         uses: greenbone/actions/poetry@v2
         with:
-          version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
       - name: Run unit tests
         run: poetry run python -m unittest
 
@@ -72,4 +72,4 @@ jobs:
       - name: Calculate and upload coverage to codecov.io
         uses: greenbone/actions/coverage-python@v2
         with:
-          version: "3.10"
+          python-version: "3.10"


### PR DESCRIPTION


## What

Use python-version input instead of version

## Why
Resolve deprecation warnings in GitHub workflows